### PR TITLE
Hesa add summary format

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,21 +21,49 @@ Scarfer can output the following information per file:
 
 * text that caused the license detection (`-m`)
 
+Scarfer can output the following summaries
+
+* license summary (using `-ls`)
+
+* copyright summary (using `-cs`)
+
+## Filter
+
 Scarfer can filter files:
 
 * include 
 
     * license name (`-il`) using Python's regular expressions
 
-    * license name (`-if`) using Python's regular expressions
+    * files (`-if`) using Python's regular expressions
+
+    * files (`-iff`) by reading a file, containing file names, using Python's regular expressions
 
 * exclude
 
     * license name (`-el`) using Python's regular expressions
 
-    * license name (`-ef`) using Python's regular expressions
+    * files (`-ef`) using Python's regular expressions
+
+    * files (`-eff`) by reading a file, containing file names, using Python's regular expressions
 
 *Note: if you're using more than one filter then filters are AND:ed together*
+
+## Curate
+
+Scarfer can curate (fix, amend) license identifications:
+
+* curate license (`-cml`) for all files with missing license
+
+* curate license (`-cfl`) for all files matching Python's regular expressions
+
+## Configuration file
+
+Scarfer can write and read configuration files:
+
+* output current (`-oc`) command line options to a configuration output
+
+* read configuration file (`--config`)
 
 # Example use
 
@@ -68,7 +96,6 @@ To filter out all files containing "/*pdi" and ending with ".c":
 ```
 $ scarfer example-data/cairo-1.16.0-scan.json -ef "/.*pdi.*\.c$"
 ```
-
 
 # Supported scan report formats
 

--- a/scarfer/format/factory.py
+++ b/scarfer/format/factory.py
@@ -1,6 +1,7 @@
 from scarfer.format.format_json import JsonFormatter
 from scarfer.format.format_yaml import YamlFormatter
 from scarfer.format.format_text import TextFormatter
+from scarfer.format.format_markdown import MarkdownFormatter
 
 
 class FormatFactory:
@@ -13,3 +14,5 @@ class FormatFactory:
             return YamlFormatter()
         elif format.lower() == "text" or format.lower() == "txt":
             return TextFormatter()
+        elif format.lower() == "markdown" or format.lower() == "md":
+            return MarkdownFormatter()

--- a/scarfer/format/format_json.py
+++ b/scarfer/format/format_json.py
@@ -5,5 +5,32 @@ from scarfer.format.interface import FormatInterface
 class JsonFormatter(FormatInterface):
 
     def format(self, report, settings={}):
-        return json.dumps(report, indent=4)
+        return json.dumps(report['files'], indent=4)
 
+    def format_cumulative(self, report, settings={}):
+        ret = []
+        cumulative = report['cumulative']
+        ret.append(" * license: {_license}".format(_license=cumulative['license']))
+        return "\n".join(ret)
+        
+    def format_license_summary(self, report, settings={}):
+        license_summary = set()
+        for f in report['files']:
+            for l in f['license']['expressions']:
+                license_summary.add(l)
+        return json.dumps({ "license": f'{ " AND ".join(license_summary)}' })
+
+    def format_copyright_summary(self, report, settings={}):
+        copyright_summary = set()
+        for f in report['files']:
+            for l in f['copyrights']:
+                copyright_summary.add(l)
+        c_list = list(copyright_summary)
+        c_list.sort()
+        c_string = "\n".join(c_list)
+        return json.dumps({ "copyrights": f'\n{c_string}' })
+
+
+
+        
+        

--- a/scarfer/format/format_markdown.py
+++ b/scarfer/format/format_markdown.py
@@ -1,0 +1,27 @@
+
+from scarfer.format.format_text import TextFormatter
+#from scarfer.format.interface import FormatInterface
+import os
+
+class MarkdownFormatter(TextFormatter):
+
+    def format_fixes(self, fixes, settings={}):
+        excluded = [ 'Excluded files:\n' ]
+        for f in fixes['excluded_files']:
+            excluded.append(f' * {f["path"]}\n')
+        missing = ['Missing license fixed:\n'] 
+        for curation in fixes['missing_license']:
+            missing.append(f' * {curation["file"]} -> {curation["curation"]}\n')
+        return f'{os.linesep.join(excluded)}{os.linesep}{os.linesep.join(missing)}'
+
+    def format_copyright_summary(self, report, settings={}):
+        copyright_summary = set()
+        for f in report['files']:
+            for l in f['copyrights']:
+                copyright_summary.add(f'{l}{os.linesep}')
+        c_list = list(copyright_summary)
+        c_list.sort()
+        c_string = "\n".join(c_list)
+        return f'{c_string}\n'
+
+    

--- a/scarfer/format/format_text.py
+++ b/scarfer/format/format_text.py
@@ -1,4 +1,5 @@
 from scarfer.format.interface import FormatInterface
+import os
 
 class TextFormatter(FormatInterface):
 
@@ -30,42 +31,45 @@ class TextFormatter(FormatInterface):
             ret.append(self._format_file(f, settings))
         return "\n".join(ret)
 
-    def _format_cumulative(self, report, settings):
+    def format(self, report, settings):
+        results = [
+            "Files:\n----------------------------",
+            self._format_files(report, settings),
+        ]
+        return "\n".join(results)
+
+    def format_fixes(self, fixes, settings={}):
+        excluded = [ 'Filtered out:' ]
+        for f in fixes['excluded_files']:
+            excluded.append(f' * {f["path"]}')
+        missing = ['Missing license fixed:'] 
+        for curation in fixes['missing_license']:
+            missing.append(f' * {curation["file"]} -> {curation["curation"]}')
+        return f'{os.linesep.join(excluded)}{os.linesep}{os.linesep.join(missing)}'
+
+    def format_cumulative(self, report, settings={}):
         ret = []
         cumulative = report['cumulative']
-        ret.append(" * license: {_license}".format(_license=cumulative['license']))
+        ret.append(f"Cumulative license: {cumulative['license']}")
         return "\n".join(ret)
         
-    
-    def format(self, report, settings):
+    def format_license_summary(self, report, settings={}):
+        license_summary = set()
+        for f in report['files']:
+            for l in f['license']['expressions']:
+                license_summary.add(l)
+        return f'License:\n { " AND ".join(license_summary)}\n'
 
-        if settings.get('license_summary') or settings.get('copyright_summary'):
-            res = ""
-            if settings.get('license_summary'):
-                license_summary = set()
-                for f in report['files']:
-                    for l in f['license']['expressions']:
-                        license_summary.add(l)
-                res += f'Licenses:\n { " AND ".join(license_summary)}\n'
+    def format_copyright_summary(self, report, settings={}):
+        copyright_summary = set()
+        for f in report['files']:
+            for l in f['copyrights']:
+                copyright_summary.add(l)
+        c_list = list(copyright_summary)
+        c_list.sort()
+        c_string = "\n".join(c_list)
+        return f'Copyrights:\n{c_string}\n'
 
-            if settings.get('copyright_summary'):
-                copyright_summary = set()
-                for f in report['files']:
-                    for l in f['copyrights']:
-                        copyright_summary.add(l)
-                c_list = list(copyright_summary)
-                c_list.sort()
-                c_string = "\n".join(c_list)
-                res += f'Copyrights:\n{c_string}\n'
-            return res
-        elif settings.get('cumulative'):
-            return self._format_cumulative(report, settings)
-        else:
-            results = [
-                "Files:\n----------------------------",
-                self._format_files(report, settings),
-            ]
-            return "\n".join(results)
 
 
         

--- a/scarfer/format/interface.py
+++ b/scarfer/format/interface.py
@@ -21,8 +21,16 @@ class FormatInterface:
     def format(self, report, settings={}):
         return 
 
+    def format_fixes(self, report, settings={}):
+        return 
 
+    def format_license_summary(self, report, settings={}):
+        return 
 
+    def format_copyright_summary(self, report, settings={}):
+        return
 
+    def format_cumulative(self, report, settings={}):
+        return 
 
 

--- a/scarfer/scan_interface.py
+++ b/scarfer/scan_interface.py
@@ -64,6 +64,7 @@ class ScanReportFilter:
 class ScanReportReader:
     def __init__(self, file_name):
         self.file_name = file_name
+        self.report_data = None
 
     def _apply_filter_file(self, filt, f):
         if filt.type == ScanReportFilterType.FILE:
@@ -241,11 +242,11 @@ class ScanReportReader:
     
     def fixes(self):
         if self.report_data == None:
-            self.apply_filters([])
+            self.apply_filters()
         return self.report_data['fixes']
 
     def raw_report(self):
-        return self.report
+        return self.report()['files']
     
     def __str__(self):
         ret = ["path: {name}".format(name=self.file_name)]

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -18,7 +18,7 @@ class TestScancodeReader_0(unittest.TestCase):
     def _setup(self, report):
         self.reader = ScanReportReader(report)
         self.reader.read()
-        self.data = self.reader.raw_report()
+        self.data = self.reader.report()['files']
         self.before_count = len(self.data)
         self.assertEqual(self.before_count, 4686)
 


### PR DESCRIPTION
With these commits comes functionality to:

Filter:
-  files (`-eff`) by reading a file, containing file names, using Python's regular expressions

Curate:
- curate license (`-cml`) for all files with missing license
- curate license (`-cfl`) for all files matching Python's regular expressions

Config file:
- output current (`-oc`) command line options to a configuration output
- read configuration file (`--config`)

